### PR TITLE
Create annotation from selection

### DIFF
--- a/annotate.css
+++ b/annotate.css
@@ -1,4 +1,5 @@
 body {
+  font-family: 'Helvetica Neue', Helvetica, sans-serif;
   font-size: 10pt;
   line-height: 1.55;
 }
@@ -39,4 +40,30 @@ table.markdown {
 }
 .line-number:before {
   content: attr(data-line) '.';
+}
+
+
+
+.tools {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+
+  overflow: scroll;
+
+  box-sizing: border-box;
+  width: 33%;
+  min-width: 3.5in;
+  padding: 1rem;
+
+  background: #ccc;
+}
+
+.tools textarea {
+  width: 100%;
+  height: 15em;
+
+  font-size: 12pt;
+  line-height: 1.45;
 }

--- a/annotate.js
+++ b/annotate.js
@@ -278,6 +278,9 @@ const store = Redux.createStore(
   })
 );
 
+store.subscribe(render, STATE);
+store.delayedDispatch = debounce(store.dispatch, 500);
+
 function render() {
   // It’s odd that the state isn’t passed to the subscriber.
   // Need to get the state from the global store itself.
@@ -288,7 +291,7 @@ function render() {
     .appendChild(renderMarkdown(state.model.content));
 }
 
-store.subscribe(render, STATE);
+
 
 document.addEventListener('DOMContentLoaded', evt => {
   render();
@@ -313,8 +316,10 @@ document.addEventListener('DOMContentLoaded', evt => {
   document.addEventListener('input', evt => {
     // TODO: Debounce
     if (evt.target && evt.target.matches('#Comment')) {
-      console.log('#Comment => change', evt.target.value);
-      store.dispatch({ type: CHANGE_COMMENT, comment: evt.target.value });
+      store.delayedDispatch({
+        type: CHANGE_COMMENT,
+        comment: evt.target.value,
+      });
     }
   });
 });

--- a/annotate.js
+++ b/annotate.js
@@ -261,8 +261,17 @@ function reducer(state, action) {
       tmp2.ui = Object.assign({}, tmp2.ui);
       tmp2.ui.comment = action.comment;
       return tmp2;
-    // case SAVE_ANNOTATION_INTENT:
-
+    case SAVE_ANNOTATION_INTENT:
+      const tmp3 = Object.assign({}, state);
+      tmp3.model = Object.assign({}, state.model);
+      tmp3.model.annotations = [...tmp3.model.annotations];
+      const annotation = Object.assign({}, action.annotation, {
+        user: state.ui.user,
+        range: state.ui.currentRange,
+      });
+      tmp3.model.annotations.push(annotation);
+      tmp3.model.annotations.sort((a, b) => a.timestamp < b.timestamp);
+      return tmp3;
     default:
       return STATE;
   }
@@ -290,8 +299,6 @@ function render() {
     .querySelector('tbody')
     .appendChild(renderMarkdown(state.model.content));
 }
-
-
 
 document.addEventListener('DOMContentLoaded', evt => {
   render();

--- a/annotate.js
+++ b/annotate.js
@@ -1,15 +1,16 @@
 const state = {
-  //currentRange: {
-  //   "start": { "row": 54, "column": 23 },
-  //   "end": { "line": 56, "column": 4 }
-  // }
-};
-const model = {
-  user: 'jmakeig',
-  annotations: [],
-  href: 'https://github.com/…',
-  commit: 'SHA',
-  content: `---
+  ui: {
+    //currentRange: {
+    //   "start": { "row": 54, "column": 23 },
+    //   "end": { "line": 56, "column": 4 }
+    // }
+  },
+  model: {
+    user: 'jmakeig',
+    annotations: [],
+    href: 'https://github.com/…',
+    commit: 'SHA',
+    content: `---
 title: MarkLogic Consolidated Vision
 author:
 - Justin Makeig
@@ -134,6 +135,7 @@ Glossier cloud bread tacos, twee jean shorts vape whatever literally locavore wo
 Taiyaki raclette hexagon, tumblr put a bird on it microdosing deep v 8-bit ethical banjo paleo next level. Brooklyn brunch gochujang, thundercats edison bulb master cleanse twee. Before they sold out meditation stumptown deep v you probably haven't heard of them farm-to-table af hella +1 copper mug bicycle rights taxidermy messenger bag. Cronut echo park quinoa banh mi semiotics keytar. Irony tilde brunch fixie. Knausgaard put a bird on it schlitz, lyft prism disrupt food truck retro freegan subway tile polaroid. Quinoa chillwave disrupt, master cleanse meggings adaptogen kinfolk iceland. Everyday carry chartreuse vape prism lo-fi. Microdosing taxidermy sartorial squid selfies, bitters kinfolk.
 
 Drinking vinegar YOLO swag, pabst cardigan 90's occupy hexagon plaid schlitz poke hot chicken banjo vape. Edison bulb heirloom venmo succulents, tilde subway tile crucifix skateboard. Vape YOLO activated charcoal craft beer ennui seitan distillery. Bespoke copper mug ugh, edison bulb craft beer banh mi hashtag yuccie cardigan tousled plaid kitsch hammock tumeric. Hell of jean shorts marfa, yuccie blue bottle put a bird on it jianbing la croix. Paleo meggings echo park franzen cold-pressed mustache gastropub ethical celiac pop-up prism gochujang. Salvia keffiyeh chillwave taxidermy. Ethical pitchfork tilde cliche polaroid beard. Copper mug neutra lumbersexual biodiesel, echo park fixie blue bottle cardigan irony put a bird on it craft beer artisan hexagon.`,
+  },
 };
 
 /**
@@ -264,7 +266,7 @@ store.subscribe(render);
 // store.dispatch({ type: 'INCREMENT' })
 
 document.addEventListener('DOMContentLoaded', evt => {
-  document.querySelector('tbody').appendChild(renderMarkdown(model.content));
+  document.querySelector('tbody').appendChild(renderMarkdown(state.model.content));
   document.querySelector('.tools #Annotate').addEventListener('click', evt => {
     store.dispatch({
       type: START_ANNOTATION,

--- a/annotate.js
+++ b/annotate.js
@@ -295,9 +295,29 @@ function render() {
   // Need to get the state from the global store itself.
   const state = store.getState();
   console.log('render', state);
-  document
-    .querySelector('tbody')
-    .appendChild(renderMarkdown(state.model.content));
+  replaceChildren(
+    renderMarkdown(state.model.content),
+    document.querySelector('tbody')
+  );
+}
+
+/**
+ * Replaces the entire contents of `oldNode` with `newChild`.
+ * It’s generally advisable to use a `DocumentFragment` for the
+ * the replacement.
+ * 
+ * @param {Node|DocumentFragment} newChild 
+ * @param {Node} oldNode 
+ * @returns {Node}  - The new parent wrapper
+ */
+function replaceChildren(newChild, oldNode) {
+  if (!oldNode) return;
+  const tmpParent = document.createElement(oldNode.tagName);
+  if (newChild) {
+    tmpParent.appendChild(newChild);
+  }
+  oldNode.parentNode.replaceChild(tmpParent, oldNode);
+  return tmpParent;
 }
 
 document.addEventListener('DOMContentLoaded', evt => {

--- a/annotate.js
+++ b/annotate.js
@@ -292,16 +292,14 @@ store.subscribe(render, STATE);
 
 document.addEventListener('DOMContentLoaded', evt => {
   render();
-  document.querySelector('.tools #Annotate').addEventListener('click', evt => {
-    store.dispatch({
-      type: START_ANNOTATION,
-      range: getRange(document.getSelection()),
-    });
-  });
-  document
-    .querySelector('.tools #SaveAnnotation')
-    .addEventListener('click', evt => {
-      console.log('SaveAnnotation');
+  document.addEventListener('click', evt => {
+    if (evt.target && evt.target.matches('#Annotate')) {
+      store.dispatch({
+        type: START_ANNOTATION,
+        range: getRange(document.getSelection()),
+      });
+    }
+    if (evt.target && evt.target.matches('#SaveAnnotation')) {
       store.dispatch({
         type: SAVE_ANNOTATION_INTENT,
         annotation: {
@@ -309,17 +307,16 @@ document.addEventListener('DOMContentLoaded', evt => {
           comment: document.querySelector('#Comment').value,
         },
       });
-    });
-  document.querySelector('.tools #Comment').addEventListener(
-    'input',
-    debounce(evt => {
+    }
+  });
+
+  document.addEventListener('input', evt => {
+    // TODO: Debounce
+    if (evt.target && evt.target.matches('#Comment')) {
       console.log('#Comment => change', evt.target.value);
-      store.dispatch({
-        type: CHANGE_COMMENT,
-        comment: evt.target.value,
-      });
-    }, 250)
-  );
+      store.dispatch({ type: CHANGE_COMMENT, comment: evt.target.value });
+    }
+  });
 });
 
 /**

--- a/annotate.js
+++ b/annotate.js
@@ -322,11 +322,19 @@ document.addEventListener('DOMContentLoaded', evt => {
   );
 });
 
-// <https://davidwalsh.name/javascript-debounce-function>
-// Returns a function, that, as long as it continues to be invoked, will not
-// be triggered. The function will be called after it stops being called for
-// N milliseconds. If `immediate` is passed, trigger the function on the
-// leading edge, instead of the trailing.
+/**
+ * Returns a function, that, as long as it continues to be invoked, will not
+ * be triggered. The function will be called after it stops being called for
+ * N milliseconds. If `immediate` is passed, trigger the function on the
+ * leading edge, instead of the trailing.
+ * 
+ * @see https://davidwalsh.name/javascript-debounce-function
+ * 
+ * @param {function} func 
+ * @param {number} [wait=500] 
+ * @param {boolean} [immediate=false] 
+ * @returns {function}
+ */
 function debounce(func, wait = 500, immediate = false) {
   var timeout;
   return function() {

--- a/annotate.js
+++ b/annotate.js
@@ -2,10 +2,6 @@ const STATE = {
   ui: {
     isRendering: false,
     user: 'jmakeig',
-    //currentRange: {
-    //   "start": { "row": 54, "column": 23 },
-    //   "end": { "line": 56, "column": 4 }
-    // }
   },
   model: {
     annotations: [],
@@ -272,7 +268,13 @@ function reducer(state, action) {
         range: state.ui.currentRange,
       });
       tmp3.model.annotations.push(annotation);
-      tmp3.model.annotations.sort((a, b) => a.timestamp < b.timestamp);
+      tmp3.model.annotations.sort((a, b) => {
+        if (a.range.start.row > b.range.start.row) return true;
+        if (a.range.start.row === b.range.start.row) {
+          return a.range.start.column > b.range.start.column;
+        }
+        return false;
+      });
       return tmp3;
     case SAVE_ANNOTATION_RECEIPT:
       const tmp4 = Object.assign({}, state);

--- a/example.html
+++ b/example.html
@@ -5,15 +5,20 @@
   <meta charset="utf-8">
   <title>Markdown</title>
   <link rel="stylesheet" href="annotate.css" />
+  <script src="https://unpkg.com/redux@latest/dist/redux.min.js"></script>
   <script src="annotate.js" type="text/javascript"></script>
 </head>
 
 <body>
   <table class="markdown">
-    <tbody>
-
-    </tbody>
+    <tbody></tbody>
   </table>
+  <div class="tools">
+    <button id="Annotate">Annotate</button>
+    <div>
+      <textarea id="Comment"></textarea>
+    </div>
+  </div>
 </body>
 
 </html>

--- a/example.html
+++ b/example.html
@@ -18,6 +18,9 @@
     <div>
       <textarea id="Comment"></textarea>
     </div>
+    <div>
+      <button id="SaveAnnotation">Save</button>
+    </div>
   </div>
 </body>
 


### PR DESCRIPTION
The UI affordances aren’t there yet, but this works end-to-end:

  1. Render Markdown
  1. Select some text
  1. Click the “Annotate” button to store the selection range
  1. Enter comments text
  1. Click “Save” to store the annotation in the global state, `.model.annotations[]` 

Fixes #13.