### PR TITLE
Reworks workflow to have explicit step to go from selection to annotation

### DIFF
--- a/annotate.css
+++ b/annotate.css
@@ -46,6 +46,21 @@ table.markdown {
   content: attr(data-line) '.';
 }
 
+#SelectAnnotation {
+  position: absolute;
+  top: -10em;
+  left: -10em;
+
+  display: none;
+
+  padding: 0.25em;
+
+  border-radius: 0.5em;
+  box-shadow: 5px 5px 10px 0 rgba(0,0,0,0.25);
+
+  background: white;
+}
+
 
 
 .tools {

--- a/example.html
+++ b/example.html
@@ -22,6 +22,9 @@
       <button id="SaveAnnotation">Save</button>
     </div>
   </div>
+  <div id="SelectAnnotation">
+    <button>🖍</button>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
Creates an explicit step to promote a selection (`state.ui.selection`) to an in-progress annotation (`state.ui.currentRange`).

Fixes #29 