### PR TITLE
Export annotated Markdown

### DIFF
--- a/annotate.js
+++ b/annotate.js
@@ -4,9 +4,11 @@ const INITIAL_STATE = {
     user: 'jmakeig',
   },
   model: {
-    annotations: null,
-    href: 'https://github.com/…',
-    commit: 'SHA',
+    annotations: [],
+    // <https://help.github.com/articles/getting-permanent-links-to-files/>
+    href:
+      'https://github.com/jmakeig/markdown-annotations/blob/fa2530c83142cd1405cca52d5caa2c2c6abc66fd/Nausgaard%20ugh%20XOXO.md',
+    commit: 'fa2530c83142cd1405cca52d5caa2c2c6abc66fd',
     content: `---
 title: MarkLogic Consolidated Vision
 author:
@@ -18,7 +20,7 @@ history: |
 
 ...
 
-# Nausgaard ugh XOXO {#nausgaard}
+## Nausgaard ugh XOXO {#nausgaard}
  
 Knausgaard ugh XOXO flannel pok pok marfa pork belly sustainable cronut la croix vice palo santo actually ethical. 
 
@@ -428,8 +430,33 @@ function render() {
   }
   document.querySelector('#CancelEditAnnotation').disabled = !active;
 
+  const download = document.querySelector('#Download');
+  // FIXME: The `toJSON` call is weird.
+  // The effect is “those that have been saved". Maybe just a rename
+  // of `clearUnsaved` to `onlyPersisted`?
+  if (state.model.annotations && state.model.annotations.toJSON().length > 0) {
+    download.href = `data:text/markdown;charset=utf-8;base64,${Base64.encode(
+      state.model.content +
+        '\n\n' +
+        serializeAnnotations(state.model.annotations)
+    )}`;
+    download.download = decodeURIComponent(state.model.href.split('/').pop());
+    download.style.display = 'unset';
+  } else {
+    download.style.display = 'none';
+  }
+
   state.ui.isRendering = false;
   console.timeEnd('render');
+}
+
+function serializeAnnotations(annotations) {
+  if (!annotations || 0 === annotations.length) {
+    return '';
+  }
+  const NAMESPACE = 'http://marklogic.com/annotations';
+  const annotationsJSON = JSON.stringify(annotations, null, 2);
+  return `<!--- ${NAMESPACE}\n\n${annotationsJSON}\n\n--->`;
 }
 
 function restoreSelection(range) {

--- a/base64.js
+++ b/base64.js
@@ -1,0 +1,121 @@
+// <https://jsfiddle.net/gabrieleromanato/qAGHT/>
+const Base64 = {
+  _keyStr: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=',
+
+  encode: function(input) {
+    var output = '';
+    var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
+    var i = 0;
+
+    input = Base64._utf8_encode(input);
+
+    while (i < input.length) {
+      chr1 = input.charCodeAt(i++);
+      chr2 = input.charCodeAt(i++);
+      chr3 = input.charCodeAt(i++);
+
+      enc1 = chr1 >> 2;
+      enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+      enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+      enc4 = chr3 & 63;
+
+      if (isNaN(chr2)) {
+        enc3 = enc4 = 64;
+      } else if (isNaN(chr3)) {
+        enc4 = 64;
+      }
+
+      output =
+        output +
+        this._keyStr.charAt(enc1) +
+        this._keyStr.charAt(enc2) +
+        this._keyStr.charAt(enc3) +
+        this._keyStr.charAt(enc4);
+    }
+
+    return output;
+  },
+
+  decode: function(input) {
+    var output = '';
+    var chr1, chr2, chr3;
+    var enc1, enc2, enc3, enc4;
+    var i = 0;
+
+    input = input.replace(/[^A-Za-z0-9\+\/\=]/g, '');
+
+    while (i < input.length) {
+      enc1 = this._keyStr.indexOf(input.charAt(i++));
+      enc2 = this._keyStr.indexOf(input.charAt(i++));
+      enc3 = this._keyStr.indexOf(input.charAt(i++));
+      enc4 = this._keyStr.indexOf(input.charAt(i++));
+
+      chr1 = (enc1 << 2) | (enc2 >> 4);
+      chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+      chr3 = ((enc3 & 3) << 6) | enc4;
+
+      output = output + String.fromCharCode(chr1);
+
+      if (enc3 != 64) {
+        output = output + String.fromCharCode(chr2);
+      }
+      if (enc4 != 64) {
+        output = output + String.fromCharCode(chr3);
+      }
+    }
+
+    output = Base64._utf8_decode(output);
+
+    return output;
+  },
+
+  _utf8_encode: function(string) {
+    string = string.replace(/\r\n/g, '\n');
+    var utftext = '';
+
+    for (var n = 0; n < string.length; n++) {
+      var c = string.charCodeAt(n);
+
+      if (c < 128) {
+        utftext += String.fromCharCode(c);
+      } else if (c > 127 && c < 2048) {
+        utftext += String.fromCharCode((c >> 6) | 192);
+        utftext += String.fromCharCode((c & 63) | 128);
+      } else {
+        utftext += String.fromCharCode((c >> 12) | 224);
+        utftext += String.fromCharCode(((c >> 6) & 63) | 128);
+        utftext += String.fromCharCode((c & 63) | 128);
+      }
+    }
+
+    return utftext;
+  },
+
+  _utf8_decode: function(utftext) {
+    var string = '';
+    var i = 0;
+    var c = (c1 = c2 = 0);
+
+    while (i < utftext.length) {
+      c = utftext.charCodeAt(i);
+
+      if (c < 128) {
+        string += String.fromCharCode(c);
+        i++;
+      } else if (c > 191 && c < 224) {
+        c2 = utftext.charCodeAt(i + 1);
+        string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
+        i += 2;
+      } else {
+        c2 = utftext.charCodeAt(i + 1);
+        c3 = utftext.charCodeAt(i + 2);
+        string += String.fromCharCode(
+          ((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63)
+        );
+        i += 3;
+      }
+    }
+
+    return string;
+  },
+};

--- a/example.html
+++ b/example.html
@@ -8,6 +8,7 @@
   <script src="https://unpkg.com/redux@latest/dist/redux.min.js"></script>
   <script src="color-hash.js" type="text/javascript"></script>
   <script src="highlight-range.js" type="text/javascript"></script>
+  <script src="base64.js" type="text/javascript"></script>
   <script src="annotate.js" type="text/javascript"></script>
 </head>
 
@@ -24,6 +25,7 @@
       <button id="DeleteAnnotation">Delete</button>
       <button id="CancelEditAnnotation">Cancel</button>
     </div>
+    <a id="Download">Download</a>
   </div>
   <div id="SelectAnnotation">
     <button>🖍</button>


### PR DESCRIPTION
Adds download linke for Markdown and serialized annotations. Uses Data URLs to encode the Markdown and the annotations serialized as JSON as base64. Downloads as `text/markdown` mime-type using the filename from `model.href`. Only shows the download link when there are persisted annotations.

Fixes #20 